### PR TITLE
File location flexibility and more quotes

### DIFF
--- a/linusquote.py
+++ b/linusquote.py
@@ -18,8 +18,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import random
-import os 
+import os
 
-lines = open(os.path.dirname(os.path.realpath(__file__)) + "/quotes").readlines()
-line  = random.choice(lines)[:-1:]
-print(line)
+print(random.choice(open(os.path.dirname(os.path.realpath(__file__)) + "/quotes").readlines())[:-1:])

--- a/linusquote.py
+++ b/linusquote.py
@@ -18,7 +18,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import random
+import os 
 
-lines = open("quotes").readlines()
+lines = open(os.path.dirname(os.path.realpath(__file__)) + "/quotes").readlines()
 line  = random.choice(lines)[:-1:]
 print(line)

--- a/quotes
+++ b/quotes
@@ -85,3 +85,9 @@ An individual developer like me cares about writing the new code and making it a
 It's a personality trait: from the very beginning, I knew what I was concentrating on. I'm only doing the kernel - I always found everything around it to be completely boring.
 What I find most interesting is how people really have taken Linux and used it in ways and attributes and motivations that I never felt.
 I'm sitting in my home office wearing a bathrobe. The same way I'm not going to start wearing ties, I'm also not going to buy into the fake politeness, the lying, the office politics and backstabbing, the passive aggressiveness, and the buzzwords.
+Of course, I'd also suggest that whoever was the genius who thought it was a good idea to read things ONE F*CKING BYTE AT A TIME with system calls for each byte should be retroactively aborted. Who the f*ck does idiotic things like that? How did they noty die as babies, considering that they were likely too stupid to find a tit to suck on?
+Nvidia, fuck you!
+kexec? Who the fuck cares? Really?
+Fix your f*cking "compliance tool", because it is obviously broken. And fix your approach to kernel programming.
+ also claim that Slashdot people usually are smelly and eat their boogers, and have an IQ slightly lower than my daughter's pet hamster (that's 'hamster' without a 'p,' btw, for any slashdot posters out there. Try to follow me, ok?).
+ Linus 'bow down before me, you scum' Torvalds

--- a/quotes
+++ b/quotes
@@ -89,5 +89,45 @@ Of course, I'd also suggest that whoever was the genius who thought it was a goo
 Nvidia, fuck you!
 kexec? Who the fuck cares? Really?
 Fix your f*cking "compliance tool", because it is obviously broken. And fix your approach to kernel programming.
- also claim that Slashdot people usually are smelly and eat their boogers, and have an IQ slightly lower than my daughter's pet hamster (that's 'hamster' without a 'p,' btw, for any slashdot posters out there. Try to follow me, ok?).
- Linus 'bow down before me, you scum' Torvalds
+also claim that Slashdot people usually are smelly and eat their boogers, and have an IQ slightly lower than my daughter's pet hamster (that's 'hamster' without a 'p,' btw, for any slashdot posters out there. Try to follow me, ok?).
+Linus 'bow down before me, you scum' Torvalds
+
+In short: just say NO TO DRUGS, and maybe you won't end up like the Hurd people.
+Hey, that's not a bug, that's a feature!
+Which mindset is right? Mine, of course. People who disagree with me are by definition crazy. (Until I change my mind, when they can suddenly become upstanding citizens. I'm flexible, and not black-and-white.)
+I'm always right. This time I'm just even more right than usual.
+ACPI was designed by a group of monkeys high on LSD
+So in order to avoid a lot of blind git users, please apply this patch.
+EFI is this other Intel brain-damage (the first one being ACPI).
+I think people can generally trust me, but they can trust me exactly because they know they don't have to.
+Nobody actually creates perfect code the first time around, except me. But there's only one of me.
+You try to claim that the GPLv3 causes "More developers", and that, my idiotic penpal, is just crazy talk that you made up.
+I don't ask for money. I don't ask for sexual favors. I don't ask for access to the hardware you design and sell. I just ask for the thing I gave you: source code that I can use myself.
+Is "I hope you all die a painful death" too strong?
+I have an ego the size of a small planet, but I'm not _always_ right [...].
+It has nothing to do with dinosaurs. Good taste doesn't go out of style
+The fact is, there aren't just two sides to any issue, there's almost always a range of responses, and "it depends" is almost always the right answer in any big question.
+I think the OpenBSD crowd is a bunch of masturbating monkeys
+And what's the Internet without the rick-roll?
+Crying that it's an application bug is like crying over the speed of light: you should deal with reality, not what you wish reality was.
+Theory and practice sometimes clash. And when that happens, theory loses. Every single time.
+Your code is shit.. your argument is shit.
+Standards are paper. I use paper to wipe my butt every day. That's how much that paper is worth.
+Every time I see some piece of medical research saying that caffeine is good for you, I high-five myself. Because I'm going to live forever.
+Good job. More public indecency, less TSA, that's what I say.
+Somebody is trying to kill all the kernel developers.
+But we kernel developers laugh in the face of danger, and a 5.5 earthquake just makes us whimper and hide in the closet for a while.
+If that's not a sign of somebody trying to kill us, I don't know what is. Handing out skate boards to a bunch of geeks sounds like a seriously misguided thing to do.
+Obsessing about things is important, and things really do matter, but if you can't let go of them, you'll end up crazy.
+WE DO NOT BREAK USERSPACE!
+I'm not sentimental. Good riddance.
+I like offending people, because I think people who get offended should be offended.
+I wish everybody was as nice as I am.
+I hope I won't end up having to hunt you all down and kill you in your sleep.
+Whoever came up with "hold the shift key for eight seconds to turn on 'your keyboard is buggered' mode" should be shot.
+There aren't enough swear-words in the English language, so now I'll have to call you perkeleen vittupää just to express my disgust and frustration with this crap.
+I don’t care about you.
+I am a lazy person, which is why I like open source, for other people to do work for me.
+Christ, people. Learn C, instead of just stringing random characters together until it compiles (with warnings).
+Get rid of it. And I don't *ever* want to see that shit again.
+We don't merge kernel code just because user space was written by a retarded monkey on crack.


### PR DESCRIPTION
Simple pull request. I added some more (expletive) quotes. 

In linusquote.py, the full path to the quotes file is discovered and referenced instead. This is more safe. Most users like to clone the repository to an arbitrary location, then create a symlink from the script to a directory in `$PATH`.  With the change in ff16be62a80dc7344823454a8b3a1344b9259134, the script will work regardless of which directory it is called from, as long as the `quotes` file is found in the same directory as `linusquote.py`. 